### PR TITLE
Stopped sending events while in debug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.9] - 7/04/19
+## [1.0.9] - 7/19/19
 * Allowed user to specifiy whether to show debug logs 
 * Disabled sending events (by default) to Mixpanel during debugging. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.9] - 7/04/19
+* Allowed user to specifiy whether to show debug logs 
+* Disabled sending events (by default) to Mixpanel during debugging. 
+
 ## [1.0.8] - 7/04/19
 * Updated Dart SDK constraints in pubspec
 * Updated all dependencies

--- a/lib/pure_mixpanel.dart
+++ b/lib/pure_mixpanel.dart
@@ -28,11 +28,12 @@ class Mixpanel {
     final uri = MixpanelUri.create(path: '/track', queryParameters: {
       'data': payload,
       'verbose': (this.debug ? '1' : '0'),
-      'ip': (this.trackIp ? '1': '0'),
+      'ip': (this.trackIp ? '1' : '0'),
     });
     if (debug) {
       print(
-          'mixpanel req\n\tproperties: $properties\n\turi: ${uri.toString()}');
+          'IN DEBUG NOT SENDING TO MIXPANEL: \n req\n\tproperties: $properties\n\turi: ${uri.toString()}');
+      return null;
     }
     return http.get(uri.toString());
   }

--- a/lib/pure_mixpanel.dart
+++ b/lib/pure_mixpanel.dart
@@ -13,8 +13,14 @@ class Mixpanel {
   final String token;
   final bool debug;
   final bool trackIp;
+  final bool showDebugLog;
 
-  Mixpanel({@required this.token, this.debug: false, this.trackIp: false});
+  Mixpanel({
+    @required this.token,
+    this.debug: false,
+    this.trackIp: false,
+    this.showDebugLog = true,
+  });
 
   Future<http.Response> track(String eventName,
       {String distinctID, Map<String, String> properties}) async {
@@ -31,8 +37,9 @@ class Mixpanel {
       'ip': (this.trackIp ? '1' : '0'),
     });
     if (debug) {
-      print(
-          'IN DEBUG NOT SENDING TO MIXPANEL: \n req\n\tproperties: $properties\n\turi: ${uri.toString()}');
+      if (showDebugLog)
+        print(
+            'IN DEBUG NOT SENDING TO MIXPANEL: \n req\n\tproperties: $properties\n\turi: ${uri.toString()}');
       return null;
     }
     return http.get(uri.toString());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pure_mixpanel
 description: A new pure Dart library for Mixpanel analytics.
-version: 1.0.8
+version: 1.0.9
 author: Nicholas Manning <puremixpanel@gmail.com>
 homepage: https://github.com/seenickcode/pure_mixpanel
 


### PR DESCRIPTION
This pull request:
* Stops sending Mixpanel events while in debug (can be changed by setting in debug to false manually)
* Allows the user to specify whether they would like to see debug logs 
* Updates `CHANGELOG.md` to reflect these changes

I think these changes would be very useful for controlling the number of events being sent to Mixpanel.  